### PR TITLE
Eliminate warning: `UserWarning: ignoring unexpected args: set([u'primaryEmail'])`

### DIFF
--- a/py/phl/phlcon_user.py
+++ b/py/phl/phlcon_user.py
@@ -39,7 +39,7 @@ QueryResponse = phlsys_namedtuple.make_named_tuple(
     'phlcon_user__QueryResponse',
     required=['phid', 'userName', 'realName', 'image', 'uri', 'roles'],
     defaults={},
-    ignored=['currentStatus', 'currentStatusUntil'])
+    ignored=['currentStatus', 'currentStatusUntil', 'primaryEmail'])
 
 
 class UserPhidCache(object):


### PR DESCRIPTION
The user query result of newer versions of Phabricator contains
`primaryEmail` attribute which arcyon does not recognize by now.