### PR TITLE
Arcyd: Change meaning and default value of max_workers

### DIFF
--- a/py/abd/abdi_processrepoarglist.py
+++ b/py/abd/abdi_processrepoarglist.py
@@ -72,7 +72,7 @@ def do(
     finished = False
 
     # decide max workers based on number of CPUs if no value is specified
-    if max_workers is None:
+    if max_workers == 0:
         try:
             # use the same default as multiprocessing.Pool
             max_workers = multiprocessing.cpu_count()
@@ -83,7 +83,7 @@ def do(
             _LOGGER.warning(
                 "multiprocessing.cpu_count() not supported, disabling "
                 "multiprocessing. Specify max workers explicitly to enable.")
-            max_workers = 0
+            max_workers = 1
 
     repo_list = []
     for name, config in repo_configs:
@@ -128,7 +128,7 @@ def do(
         with abdt_logging.misc_operation_event_context(
                 'process-repos',
                 '{} workers, {} repos'.format(max_workers, len(repo_list))):
-            if max_workers:
+            if max_workers > 1:
                 for i, res in pool.cycle_results(overrun_secs=overrun_secs):
                     repo = repo_list[i]
                     repo.merge_from_worker(res)

--- a/py/abd/abdi_processrepos.py
+++ b/py/abd/abdi_processrepos.py
@@ -88,9 +88,9 @@ def setupParser(parser):
         '--max-workers',
         metavar="COUNT",
         type=int,
-        default=None,
-        help="maximum number of worker processes to run at one time, leave "
-             "unset to let Arcyd decide the number. Set to 0 to disable "
+        default=0,
+        help="maximum number of worker processes to run at one time, Set to 0 "
+             "to let Arcyd decide the number. Set to 1 to disable "
              "multiprocessing completely.")
     parser.add_argument(
         '--overrun-secs',


### PR DESCRIPTION
Existing default for max_workers is None which is not a valid integer. Change
its default value to 0. If number of max_workers is to be determined
automatically, leave this value as 0. To disable multiprocessing completely,
set it to 1.

Test plan:
$ ./precommit.sh