### PR TITLE
Arcyd-tester: Add option to disable auto debug shell

### DIFF
--- a/py/ate/atecmd_arcydtester.py
+++ b/py/ate/atecmd_arcydtester.py
@@ -95,6 +95,14 @@ def main():
              'to exercise concurrency and gather more accurate performance '
              'information.')
 
+    parser.add_argument(
+        '--enable-debug-shell',
+        action='store_true',
+        default=False,
+        help='If this argument is provided, debug shell is launched '
+             'automatically if any of the tests fail. By default, this option '
+             'is set to false.')
+
     args = parser.parse_args()
 
     with phlsys_fs.chtmpdir_context():
@@ -399,7 +407,8 @@ def _do_tests(args):
             run_all_interactions(fixture)
         except:
             print(fixture.arcyds[0].debug_log())
-            fixture.launch_debug_shell()
+            if args.enable_debug_shell:
+                fixture.launch_debug_shell()
             raise
 
 


### PR DESCRIPTION
At present, if any of the tests fail, debug shell is launched
automatically. This behavior is not natural, especially for new users.
This commit adds a command line option to the script to enable the
automatic launch of debug shell but it is set to false by default. To
enable it, the script should be passed a '--enable-debug-shell' option.

Test plan:
$ ./precommit.sh

(Manual) Try to run the script with '--enable-debug-shell' and esnure
that it automatically opens the debug shell on a failure. Running it
without that option should not result in opening of a shell.