### PR TITLE
Arcyd: fix caching for --no-loop and max-workers=1

### DIFF
--- a/py/abd/abdi_processrepoarglist.py
+++ b/py/abd/abdi_processrepoarglist.py
@@ -95,8 +95,7 @@ def do(
 
     cycle_timer = phlsys_timer.Timer()
     cycle_timer.start()
-    finished = False
-    while not finished:
+    while True:
 
         # This timer needs to be separate from the cycle timer. The cycle timer
         # must be reset every time it is reported. The sleep timer makes sure
@@ -166,7 +165,6 @@ def do(
             if os.path.isfile(kill_file):
                 os.remove(kill_file)
 
-            finished = True
             break
 
         # sleep to pad out the cycle

--- a/py/abd/abdi_processrepoarglist.py
+++ b/py/abd/abdi_processrepoarglist.py
@@ -152,7 +152,7 @@ def do(
                         e))
 
         # look for killfile
-        if os.path.isfile(kill_file):
+        if os.path.isfile(kill_file) or is_no_loop:
 
             # finish any jobs that overran
             for i, res in pool.finish_results():
@@ -163,11 +163,9 @@ def do(
             # possible after doing fetches
             url_watcher_wrapper.save()
 
-            os.remove(kill_file)
-            finished = True
-            break
+            if os.path.isfile(kill_file):
+                os.remove(kill_file)
 
-        if is_no_loop:
             finished = True
             break
 
@@ -205,7 +203,7 @@ class _RecordingWatcherWrapper(object):
 
     def has_url_recently_changed(self, url):
         self._tested_urls.add(url)
-        return self._watcher.peek_has_url_recently_changed(url)
+        return self._watcher.has_url_recently_changed(url)
 
     @property
     def tested_urls(self):


### PR DESCRIPTION
It turns out that we weren't consuming the 'newness' of the snoop urls
in the case where we're not multiprocessing and in the case where we're
not looping.

In the non-multiprocessing case, we simply weren't consuming the
newness.

In the --no-loop case, we weren't writing the cache to disk.

This resulted in fetching more times than was necessary.

Test Plan:
$ ./precommit

$ ./testbed/arcyd/test_shell.sh
    $ sed -i '/--max-workers/{n;s/0/1/}' ../arcyd/configfile
    $ grep -A 1 -- '--max-workers' ../arcyd/configfile
    --max-workers
    1
    $ cd ../arcyd
    $ arcyd stop
    $ ~/repos/phabricator-tools/proto/arcyd stop
    $ cat .arcyd.urlwatcher.cache
    ... ["8296dc818c89de923afab693bfefc2e2a26f3081", false]}
    $ cd ../dev
    $ ./poke.sh
    $ cd ../arcyd
    $ ~/repos/phabricator-tools/proto/arcyd start --no-loop
    $ cat .arcyd.urlwatcher.cache
    ... ["e99c3848d7ed9b438896e478cd39de21cacc22b6", false]}