### PR TITLE
Arcyd: --repo-push-url-format for repohosts

### DIFF
--- a/doc/man/arcyd/arcyd_add-repohost.generated.txt
+++ b/doc/man/arcyd/arcyd_add-repohost.generated.txt
@@ -1,4 +1,5 @@
 usage: arcyd add-repohost [-h] --name STR [--repo-url-format STRING]
+                          [--repo-push-url-format STRING]
                           [--repo-snoop-url-format URL]
                           [--branch-url-format STRING]
                           [--admin-emails [TO [TO ...]]]
@@ -13,6 +14,10 @@ optional arguments:
                         argument to produce the final url, e.g.
                         'http://github.com/{}.git'. the default is '{}' so the
                         '--repo-url' is used unchanged.
+  --repo-push-url-format STRING
+                        a python format() string to apply the '--repo-url'
+                        argument to produce a push url, e.g.
+                        'http://github.com/{}.git'.
   --repo-snoop-url-format URL
                         URL to use to snoop the latest contents of the
                         repository, this is used by Arcyd to more efficiently

--- a/py/abd/abdcmd_addrepo.py
+++ b/py/abd/abdcmd_addrepo.py
@@ -183,13 +183,16 @@ def process(args):
     # determine the repo url from the parsed params
     repo_url = abdi_repoargs.get_repo_url(repo_params)
 
+    # determine the repo push url from the parsed params
+    repo_push_url = abdi_repoargs.get_repo_push_url(repo_params)
+
     with fs.lockfile_context():
-        with abdi_repo.setup_repo_context(repo_url, repo_path):
+        with abdi_repo.setup_repo_context(repo_url, repo_path, repo_push_url):
             fs.create_repo_config(repo_name, config)
 
 
 # -----------------------------------------------------------------------------
-# Copyright (C) 2014 Bloomberg Finance L.P.
+# Copyright (C) 2014-2015 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/py/abd/abdcmd_addrepohost.py
+++ b/py/abd/abdcmd_addrepohost.py
@@ -26,6 +26,11 @@ _CONFIG_REPO_URL_FORMAT = """
 {repo_url_format}
 """.strip()
 
+_CONFIG_REPO_PUSH_URL_FORMAT = """
+--repo-push-url-format
+{repo_push_url_format}
+""".strip()
+
 _CONFIG_REPO_SNOOP_URL_FORMAT = """
 --repo-snoop-url-format
 {repo_snoop_url_format}
@@ -77,6 +82,12 @@ def process(args):
             config,
             _CONFIG_REPO_URL_FORMAT.format(
                 repo_url_format=args.repo_url_format)])
+
+    if args.repo_push_url_format:
+        config = '\n'.join([
+            config,
+            _CONFIG_REPO_PUSH_URL_FORMAT.format(
+                repo_push_url_format=args.repo_push_url_format)])
 
     if args.repo_snoop_url_format:
         config = '\n'.join([

--- a/py/abd/abdcmd_fsck.py
+++ b/py/abd/abdcmd_fsck.py
@@ -167,8 +167,10 @@ def _check_repo_cloned(args, repo_name, repo_config):
             repo_name, repo_config.repo_path))
         if args.fix:
             repo_url = abdi_repoargs.get_repo_url(repo_config)
+            repo_push_url = abdi_repoargs.get_repo_push_url(repo_config)
             print("cloning '{}' ..".format(repo_url))
-            abdi_repo.setup_repo(repo_url, repo_config.repo_path)
+            abdi_repo.setup_repo(
+                repo_url, repo_config.repo_path, repo_push_url)
         else:
             all_ok = False
 
@@ -291,7 +293,7 @@ def _print_indented(spaces, s):
 
 
 # -----------------------------------------------------------------------------
-# Copyright (C) 2014 Bloomberg Finance L.P.
+# Copyright (C) 2014-2015 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/py/abd/abdi_repo.py
+++ b/py/abd/abdi_repo.py
@@ -51,30 +51,38 @@ being created.
 """.strip()
 
 
-def setup_repo(repo_url, repo_path):
+def setup_repo(repo_url, repo_path, repo_push_url=None):
     """Setup a repository, if an exception is raised then remove the repo.
 
     :repo_url: string url of the repo to clone
     :repo_path: string path to clone the repo to
+    :repo_push_url: string url to push to, or None
     :returns: None
 
     """
-    with setup_repo_context(repo_url, repo_path):
+    with setup_repo_context(repo_url, repo_path, repo_push_url):
         pass
 
 
 @contextlib.contextmanager
-def setup_repo_context(repo_url, repo_path):
+def setup_repo_context(repo_url, repo_path, repo_push_url=None):
     """Setup a repository, if an exception is raised then remove the repo.
 
     :repo_url: string url of the repo to clone
     :repo_path: string path to clone the repo to
+    :repo_push_url: string url to push to, or None
     :returns: None
 
     """
     # if there's any failure after cloning then we should remove the repo
-    phlsys_subprocess.run(
-        'git', 'clone', repo_url, repo_path)
+    if repo_push_url is not None:
+        phlsys_subprocess.run(
+            'git', 'clone', repo_url, repo_path,
+            '--config', 'remote.origin.pushurl=' + repo_push_url)
+    else:
+        phlsys_subprocess.run(
+            'git', 'clone', repo_url, repo_path)
+
     try:
         repo = phlsys_git.Repo(repo_path)
 
@@ -180,7 +188,7 @@ def remove_landinglog(repo):
 
 
 # -----------------------------------------------------------------------------
-# Copyright (C) 2014 Bloomberg Finance L.P.
+# Copyright (C) 2014-2015 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/py/abd/abdi_repoargs.py
+++ b/py/abd/abdi_repoargs.py
@@ -8,6 +8,7 @@
 #   parse_config_file_list
 #   validate_args
 #   get_repo_url
+#   get_repo_push_url
 #   get_repo_snoop_url
 #   setup_parser
 #   setup_phab_parser
@@ -65,6 +66,19 @@ def get_repo_url(args):
 
     """
     return args.repo_url_format.format(args.repo_url)
+
+
+def get_repo_push_url(args):
+    """Return the fully expanded push url for this repo or None.
+
+    :args: the namespace returned from the argparse parser
+    :returns: string url to push the repo, or None
+
+    """
+    url = None
+    if args.repo_push_url_format:
+        url = args.repo_push_url_format.format(args.repo_url)
+    return url
 
 
 def get_repo_snoop_url(args):
@@ -183,6 +197,14 @@ def setup_repohost_parser(parser):
         help="a python format() string to apply the '--repo-url' argument to "
              "produce the final url, e.g. 'http://github.com/{}.git'. the "
              "default is '{}' so the '--repo-url' is used unchanged.")
+
+    parser.add_argument(
+        '--repo-push-url-format',
+        metavar="STRING",
+        type=str,
+        help="a python format() string to apply the '--repo-url' "
+             "argument to produce a push url, e.g. "
+             "'http://github.com/{}.git'.")
 
     parser.add_argument(
         '--repo-snoop-url-format',

--- a/testbed/arcyd/test_shell.sh
+++ b/testbed/arcyd/test_shell.sh
@@ -158,7 +158,8 @@ vot7fxrotwpi3ty2b2sa2kvlpf
 
     $arcyd add-repohost \
         --name fs1 \
-        --repo-url-format '../{}' \
+        --repo-url-format 'http://localhost:8000' \
+        --repo-push-url-format $(readlink -f ../)'/{}' \
         --repo-snoop-url-format 'http://localhost:8000/info/refs' \
         --branch-url-format 'http://my.git/gitweb?p={repo_url}.git;a=log;h=refs/heads/{branch}' \
         --admin-emails 'local-git-admin2@localhost' 'local-git-admin@localhost'


### PR DESCRIPTION
Authorization and authentication on Git repository hosts is often
expensive. Some services offer different URLs for auth'd vs. non-auth'd
access.

Arcyd can now make good use of cheaper, non-auth'd routes. As it may be
handling many repositories, this is worth setting up.

Teach 'arcyd add-repohost' a new option: --repo-push-url-format, so we
can specify a different URL for auth'd pushing and non-auth'd fetching.

Add support for Git's 'pushurl' option, so that we can use a non-auth'd
route for fetching and an auth'd route for pushing.

Modify Arcyd test shell so that the 'arcyd2' instance uses a specific
push url format.

Test Plan:

Ensure that push url is set correctly and is actually used by git.

$ ./testbed/arcyd/test_shell.sh
    $ cd ../arcyd2/var/repo/localhost_fs1_origin/

    $ git config --local -l | grep url
    remote.origin.pushurl=/tmp/tmp.eaxOxHHMce/origin
    remote.origin.url=http://localhost:8000

    $ git fetch -v | head -1
    From http://localhost:8000

    $ git push -v | head -1
    Pushing to /tmp/tmp.eaxOxHHMce/origin