### PR TITLE
Arcyd: Add reason for stopping to info logs

### DIFF
--- a/doc/man/arcyd/arcyd_stop.generated.txt
+++ b/doc/man/arcyd/arcyd_stop.generated.txt
@@ -1,6 +1,8 @@
-usage: arcyd stop [-h]
+usage: arcyd stop [-h] [-m MESSAGE]
 
 Stop the arcyd instance for the current directory.
 
 optional arguments:
-  -h, --help  show this help message and exit
+  -h, --help            show this help message and exit
+  -m MESSAGE, --message MESSAGE
+                        reason for stopping arcyd

--- a/py/abd/abdcmd_restart.py
+++ b/py/abd/abdcmd_restart.py
@@ -37,13 +37,19 @@ def setupParser(parser):
         '--no-loop',
         action='store_true',
         help="supply this argument to only process each repo once then exit")
+    parser.add_argument(
+        '-m',
+        '--message',
+        default='',
+        help="reason for restarting arcyd")
 
 
 def process(args):
     logging.getLogger().setLevel(logging.DEBUG)
     abdi_startstop.start_arcyd(daemonize=not args.foreground,
                                loop=not args.no_loop,
-                               restart=True)
+                               restart=True,
+                               stop_message=args.message)
 
 # -----------------------------------------------------------------------------
 # Copyright (C) 2015 Bloomberg Finance L.P.

--- a/py/abd/abdcmd_stop.py
+++ b/py/abd/abdcmd_stop.py
@@ -25,11 +25,15 @@ def getFromfilePrefixChars():
 
 
 def setupParser(parser):
-    pass
+    parser.add_argument(
+        '-m',
+        '--message',
+        default='',
+        help="reason for stopping arcyd")
 
 
-def process(unused_args):
-    abdi_startstop.stop_arcyd()
+def process(args):
+    abdi_startstop.stop_arcyd(args.message)
 
 
 # -----------------------------------------------------------------------------

--- a/py/abd/abdi_processrepoarglist.py
+++ b/py/abd/abdi_processrepoarglist.py
@@ -27,6 +27,7 @@ import phlcon_reviewstatecache
 import phlgitx_refcache
 import phlmp_cyclingpool
 import phlsys_conduit
+import phlsys_fs
 import phlsys_git
 import phlsys_strtotime
 import phlsys_subprocess
@@ -155,6 +156,9 @@ def do(
             exit_code = abdi_processexitcodes.ExitCodes.ec_exit
         elif os.path.isfile(fs_accessor.layout.killfile):
             exit_code = abdi_processexitcodes.ExitCodes.ec_exit
+            if phlsys_fs.read_text_file(fs_accessor.layout.killfile):
+                _LOGGER.info("Reason for stopping arcyd: {}".format(
+                    phlsys_fs.read_text_file(fs_accessor.layout.killfile)))
             os.remove(fs_accessor.layout.killfile)
         elif os.path.isfile(fs_accessor.layout.reloadfile):
             exit_code = abdi_processexitcodes.ExitCodes.ec_reload


### PR DESCRIPTION
When Arcyd stops gracefully, a log entry is left in /var/log/info. This
is useful for knowing when Arcyd was stopped. It would be helpful to
have a reason in the log as well. This commit adds command line
argument "-m"/"--message" to "arcyd stop" and "arcyd restart" commands
to supply this reason.

This argument is optional but it is highly recommended to provide this
argument whenever stopping or restarting Arcyd.

Test plan:
$ ./precommit.sh

Launch Arcyd test shell using ./testbed/arcyd/test_shell.sh. Now, stop
Arcyd using following command:
  $ arcyd stop -m "Stopped arcyd to ensure this message is logged"

Now ensure that /var/log/info contains an entry similar to the
following:
  INFO: Reason for stopping Arcyd: Stopped arcyd to ensure this message is logged
  INFO: stopped arcyd

Start Arcyd again using following command:
  $ arcyd start

Now, restart Arcyd using following command:
  $ arcyd restart -m "Restarted arcyd to ensure this message is logged"

Now ensure that /var/log/info contains an entry similar to the
following:
  INFO: Reason for stopping Arcyd: Restarted arcyd to ensure this message is logged
  INFO: stopped arcyd
  INFO: started arcyd

Fixes #39