### PR TITLE
Arcyd: reload command

### DIFF
--- a/doc/man/arcyd/arcyd.generated.txt
+++ b/doc/man/arcyd/arcyd.generated.txt
@@ -1,5 +1,5 @@
 usage: arcyd [-h]
-             {init,list-repos,add-phabricator,add-repohost,add-repo,rm-repo,start,stop,restart,fsck,fetch}
+             {init,list-repos,add-phabricator,add-repohost,add-repo,rm-repo,start,stop,restart,reload,fsck,fetch}
              ...
 
 Arcyd - daemon to watch git repos, create and land reviews automatically.
@@ -25,7 +25,7 @@ minimal user workflow:
     .. Arcyd squashes the 'arcyd-review' branch onto master and deletes it ..
 
 positional arguments:
-  {init,list-repos,add-phabricator,add-repohost,add-repo,rm-repo,start,stop,restart,fsck,fetch}
+  {init,list-repos,add-phabricator,add-repohost,add-repo,rm-repo,start,stop,restart,reload,fsck,fetch}
     init                Create a new arcyd instance in working dir, with
                         backing git repository.
     list-repos          List the repositories managed by this arcyd instance.
@@ -39,6 +39,7 @@ positional arguments:
                         not already going.
     stop                Stop the arcyd instance for the current directory.
     restart             Restart the arcyd instance for the current directory.
+    reload              Reload the arcyd instance for the current directory.
     fsck                Check the Arcyd files for consistency and fix any
                         issues.
     fetch               Fetch managed repos.

--- a/py/abd/README.md
+++ b/py/abd/README.md
@@ -15,6 +15,8 @@ Check the Arcyd files for consistency and fix any issues.
 Create a new arcyd instance in working dir, with backing git repository.
 * `abdcmd_listrepos.py` -
 List the repositories managed by this arcyd instance.
+* `abdcmd_reload.py` -
+Reload the arcyd instance for the current directory.
 * `abdcmd_restart.py` -
 Restart the arcyd instance for the current directory.
 * `abdcmd_rmrepo.py` -
@@ -25,6 +27,8 @@ Start the arcyd instance for the current directory, if not already going.
 Stop the arcyd instance for the current directory.
 * `abdcmnt_commenter.py` -
 Make pre-defined comments on Differential revisions.
+* `abdi_processexitcodes.py` -
+Setup to process multiple repos.
 * `abdi_processrepo.py` -
 abd automates the creation and landing of reviews from branches.
 * `abdi_processrepoarglist.py` -

--- a/py/abd/abdcmd_arcyd.py
+++ b/py/abd/abdcmd_arcyd.py
@@ -48,6 +48,7 @@ import abdcmd_fetch
 import abdcmd_fsck
 import abdcmd_init
 import abdcmd_listrepos
+import abdcmd_reload
 import abdcmd_restart
 import abdcmd_rmrepo
 import abdcmd_start
@@ -120,6 +121,8 @@ def main():
         "stop", abdcmd_stop, subparsers)
     phlsys_subcommand.setup_parser(
         "restart", abdcmd_restart, subparsers)
+    phlsys_subcommand.setup_parser(
+        "reload", abdcmd_reload, subparsers)
     phlsys_subcommand.setup_parser(
         "fsck", abdcmd_fsck, subparsers)
     phlsys_subcommand.setup_parser(

--- a/py/abd/abdcmd_init.py
+++ b/py/abd/abdcmd_init.py
@@ -29,8 +29,6 @@ _DEFAULT_CONFIG = """
 {sendmail_binary}
 --sendmail-type
 {sendmail_type}
---kill-file
-var/command/killfile
 --sleep-secs
 {sleep_secs}
 --max-workers

--- a/py/abd/abdcmd_reload.py
+++ b/py/abd/abdcmd_reload.py
@@ -1,0 +1,51 @@
+"""Reload the arcyd instance for the current directory."""
+# =============================================================================
+# CONTENTS
+# -----------------------------------------------------------------------------
+# abdcmd_reload
+#
+# Public Functions:
+#   getFromfilePrefixChars
+#   setupParser
+#   process
+#
+# -----------------------------------------------------------------------------
+# (this contents block is generated, edits will be lost)
+# =============================================================================
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import logging
+
+import abdi_startstop
+
+
+def getFromfilePrefixChars():
+    return None
+
+
+def setupParser(parser):
+    pass
+
+
+def process(unused_args):
+    logging.getLogger().setLevel(logging.DEBUG)
+    abdi_startstop.reload_arcyd()
+
+# -----------------------------------------------------------------------------
+# Copyright (C) 2014-2015 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------ END-OF-FILE ----------------------------------

--- a/py/abd/abdi_processexitcodes.py
+++ b/py/abd/abdi_processexitcodes.py
@@ -1,0 +1,37 @@
+"""Setup to process multiple repos."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# =============================================================================
+# CONTENTS
+# -----------------------------------------------------------------------------
+# abdi_processexitcodes
+#
+# Public Classes:
+#   ExitCodes
+#
+# -----------------------------------------------------------------------------
+# (this contents block is generated, edits will be lost)
+# =============================================================================
+
+
+class ExitCodes(object):
+    ec_exit = 'ec_exit'
+    ec_reload = 'ec_reload'
+
+
+# -----------------------------------------------------------------------------
+# Copyright (C) 2015 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------ END-OF-FILE ----------------------------------

--- a/py/abd/abdi_processrepoarglist.py
+++ b/py/abd/abdi_processrepoarglist.py
@@ -46,6 +46,7 @@ import abdt_logging
 import abdt_rbranchnaming
 import abdt_tryloop
 
+import abdi_processexitcodes
 import abdi_processrepo
 import abdi_repoargs
 
@@ -94,8 +95,8 @@ def do(
 
     cycle_timer = phlsys_timer.Timer()
     cycle_timer.start()
-    finished = False
-    while not finished:
+    exit_code = None
+    while exit_code is None:
 
         # This timer needs to be separate from the cycle timer. The cycle timer
         # must be reset every time it is reported. The sleep timer makes sure
@@ -145,32 +146,32 @@ def do(
                 except phlsys_subprocess.CalledProcessError as e:
                     _LOGGER.error("CycleReportJson: {}".format(e))
 
-        # look for killfile
-        if os.path.isfile(fs_accessor.layout.killfile):
-
-            # finish any jobs that overran
-            for i, res in pool.finish_results():
-                repo = repo_list[i]
-                repo.merge_from_worker(res)
-
-            # important to do this before stopping arcyd and as soon as
-            # possible after doing fetches
-            url_watcher_wrapper.save()
-
-            os.remove(fs_accessor.layout.killfile)
-            finished = True
-            break
-
         if is_no_loop:
-            finished = True
-            break
+            exit_code = abdi_processexitcodes.ExitCodes.ec_exit
+        elif os.path.isfile(fs_accessor.layout.killfile):
+            exit_code = abdi_processexitcodes.ExitCodes.ec_exit
+            os.remove(fs_accessor.layout.killfile)
+        elif os.path.isfile(fs_accessor.layout.reloadfile):
+            exit_code = abdi_processexitcodes.ExitCodes.ec_reload
+            os.remove(fs_accessor.layout.reloadfile)
 
         # sleep to pad out the cycle
         secs_to_sleep = float(sleep_secs) - float(sleep_timer.duration)
-        if secs_to_sleep > 0:
+        if secs_to_sleep > 0 and exit_code is None:
             with abdt_logging.misc_operation_event_context(
                     'sleep', secs_to_sleep):
                 time.sleep(secs_to_sleep)
+
+    # finish any jobs that overran
+    for i, res in pool.finish_results():
+        repo = repo_list[i]
+        repo.merge_from_worker(res)
+
+    # important to do this before stopping arcyd and as soon as
+    # possible after doing fetches
+    url_watcher_wrapper.save()
+
+    return exit_code
 
 
 def determine_max_workers_default():

--- a/py/abd/abdi_processrepoarglist.py
+++ b/py/abd/abdi_processrepoarglist.py
@@ -56,7 +56,6 @@ _LOGGER = logging.getLogger(__name__)
 def do(
         repo_configs,
         sys_admin_emails,
-        kill_file,
         sleep_secs,
         is_no_loop,
         external_report_command,
@@ -147,7 +146,7 @@ def do(
                     _LOGGER.error("CycleReportJson: {}".format(e))
 
         # look for killfile
-        if os.path.isfile(kill_file):
+        if os.path.isfile(fs_accessor.layout.killfile):
 
             # finish any jobs that overran
             for i, res in pool.finish_results():
@@ -158,7 +157,7 @@ def do(
             # possible after doing fetches
             url_watcher_wrapper.save()
 
-            os.remove(kill_file)
+            os.remove(fs_accessor.layout.killfile)
             finished = True
             break
 

--- a/py/abd/abdi_processrepos.py
+++ b/py/abd/abdi_processrepos.py
@@ -81,12 +81,6 @@ def setupParser(parser):
         required=True,
         help="email addresses to send important system events to")
     parser.add_argument(
-        '--kill-file',
-        metavar="NAME",
-        type=str,
-        help="filename to watch for, will stop operations safely if the file "
-             "is detected.")
-    parser.add_argument(
         '--no-loop',
         action='store_true',
         help="supply this argument to only process each repo once then exit")
@@ -129,17 +123,16 @@ def process(args, repo_configs):
         "arcyd stopped with exception",
         "")
 
-    _processrepolist(
+    return _processrepolist(
         args, repo_configs, on_exception, mail_sender)
 
 
 def _processrepolist(
         args, repo_configs, on_exception, mail_sender):
     try:
-        abdi_processrepoarglist.do(
+        return abdi_processrepoarglist.do(
             repo_configs,
             args.sys_admin_emails,
-            args.kill_file,
             args.sleep_secs,
             args.no_loop,
             args.external_report_command,

--- a/py/abd/abdi_startstop.py
+++ b/py/abd/abdi_startstop.py
@@ -8,6 +8,7 @@
 #   start_arcyd
 #   stop_arcyd
 #   stop_arcyd_pid
+#   reload_arcyd
 #
 # -----------------------------------------------------------------------------
 # (this contents block is generated, edits will be lost)
@@ -32,6 +33,7 @@ import phlsys_signal
 
 import abdt_fs
 
+import abdi_processexitcodes
 import abdi_processrepos
 import abdi_repoargs
 
@@ -81,11 +83,24 @@ def start_arcyd(daemonize=True, loop=True, restart=False):
 
     with phlsys_multiprocessing.logging_context(logger_config):
         _LOGGER.debug("start with args: {}".format(args))
-        _LOGGER.info("arcyd started")
-        try:
-            abdi_processrepos.process(args, repo_configs)
-        finally:
-            _LOGGER.info("arcyd stopped")
+        while True:
+            _LOGGER.info("arcyd started")
+            try:
+                exit_code = abdi_processrepos.process(args, repo_configs)
+                _LOGGER.debug("arcyd process loop exit_code: %s" % exit_code)
+                if exit_code == abdi_processexitcodes.ExitCodes.ec_exit:
+                    break
+            finally:
+                _LOGGER.info("arcyd stopped")
+
+            _LOGGER.debug("reloading arcyd configuration")
+            try:
+                with fs.lockfile_context():
+                    repo_configs = abdi_repoargs.parse_config_file_list(
+                        fs.repo_config_path_list())
+            except phlsys_fs.LockfileExistsError:
+                _LOGGER.debug("couldn't acquire lockfile context")
+                _LOGGER.debug("repo_config reload failed")
 
 
 def stop_arcyd():
@@ -113,6 +128,17 @@ def stop_arcyd_pid(pid, killfile):
         while phlsys_pid.is_running(pid):
             print('waiting for arcyd to exit')
             time.sleep(1)
+
+
+def reload_arcyd():
+    fs = abdt_fs.make_default_accessor()
+
+    with fs.lockfile_context():
+        pid = fs.get_pid_or_none()
+        if pid is None or not phlsys_pid.is_running(pid):
+            raise Exception("Arcyd is not running")
+
+        phlsys_fs.write_text_file('var/command/reload', '')
 
 
 def _setup_logger(fs):

--- a/py/abd/abdi_startstop.py
+++ b/py/abd/abdi_startstop.py
@@ -48,7 +48,7 @@ def start_arcyd(daemonize=True, loop=True, restart=False):
         pid = fs.get_pid_or_none()
         if pid is not None and phlsys_pid.is_running(pid):
             if restart:
-                stop_arcyd_pid(pid)
+                stop_arcyd_pid(pid, fs.layout.killfile)
             else:
                 raise Exception("already running")
 
@@ -95,11 +95,10 @@ def stop_arcyd():
         pid = fs.get_pid_or_none()
         if pid is None or not phlsys_pid.is_running(pid):
             raise Exception("Arcyd is not running")
-        stop_arcyd_pid(pid)
+        stop_arcyd_pid(pid, fs.layout.killfile)
 
 
-def stop_arcyd_pid(pid):
-    killfile = 'var/command/killfile'
+def stop_arcyd_pid(pid, killfile):
     phlsys_fs.write_text_file(killfile, '')
 
     if os.path.isfile(killfile):

--- a/py/abd/abdt_fs.py
+++ b/py/abd/abdt_fs.py
@@ -147,6 +147,7 @@ class Layout(object):
     repository_config_dir = 'config/repository'
     urlwatcher_cache_path = '.arcyd.urlwatcher.cache'
     lockfile = 'var/lockfile'
+    killfile = 'var/command/killfile'
 
     dir_run = 'var/run'
 

--- a/py/abd/abdt_fs.py
+++ b/py/abd/abdt_fs.py
@@ -148,6 +148,7 @@ class Layout(object):
     urlwatcher_cache_path = '.arcyd.urlwatcher.cache'
     lockfile = 'var/lockfile'
     killfile = 'var/command/killfile'
+    reloadfile = 'var/command/reload'
 
     dir_run = 'var/run'
 

--- a/py/ate/atecmd_arcydtester.py
+++ b/py/ate/atecmd_arcydtester.py
@@ -169,7 +169,7 @@ class _Worker(object):
         self._repo('fetch', '--prune')
 
     def list_reviews(self):
-        return json.loads(self.barc('list', '--format-json'))
+        return json.loads(self._barc('list', '--format-json'))
 
     def _arcyon_action(self, review_id, action):
         connection_args = [


### PR DESCRIPTION
The 'arcyd reload' command triggers the configuration reload by
arcyd daemon - without the need to stop and start the daemon.

Test Plan:
Use ./testbed/arcyd/test_shell.sh to exercise start stop and reload
commands.

Breaking changes:
* removed --killfile command line option