### PR TITLE
Meta: Run pre-commit tests on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,8 @@ language: python
 python:
   - "2.7"
 
-# Install pip using apt
-addons:
-  apt:
-    packages:
-    - python-pip
-
-# Install dependencies using pip
 install:
+  # Install dependencies using pip
   - pip install autopep8
   - pip install docformatter
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,11 @@ install:
   - pip install pylint
   - pip install snakefood
 
-# command to run tests
-script: ./static_tests.sh
+before_script:
+  # This is necessary because Travis shallow clones the repo and we require the
+  # entire log to run meta/autofix/fixlegal.py
+  - git fetch --unshallow
+
+script:
+  # Run code checks and tests while exclding those which require phabricator.
+  - ./precommit.sh -e unit_tests -e smoke_tests


### PR DESCRIPTION
At present, we only run static_tests.sh script on Travis CI but it is
fairly straightforward to run gen_doc.sh and autofix.sh scripts as well.
This change adds those scripts to Travis build script so it should now
be able to detect fails from those scripts as well.

Test plan:
$ ./precommit.sh

Ensure that the builds pass on Travis CI with these set of changes on
current codebase.

Ensure that the builds fail if there's a missing doc update or autofix
issues after applying this patch.