### PR TITLE
precommit.sh: handle unexpected extra arguments

### DIFF
--- a/precommit.sh
+++ b/precommit.sh
@@ -52,6 +52,14 @@ while getopts "e:h" opt; do
     esac
 done
 
+shift $((OPTIND-1))
+if [[ -n "$@" ]]; then
+    print_help
+    echo
+    echo Unexpected arguments: "$@"
+    exit 1
+fi
+
 # in the event of an error, print 'FAIL' and exit with code 1
 trap 'echo FAIL; exit 1' ERR
 


### PR DESCRIPTION
Now that precommit can ignore individual tests, people will start
supplying arguments to the program.

If people supply unexpected arguments then print the help and the
unexpected arguments.

Test Plan:
$ ./precommit.sh
$ ./precommit.sh -e static_tests -e unit_tests -e smoke_tests

$ ./precommit.sh -e static_tests unit_tests smoke_tests
...
Unexpected arguments: unit_tests smoke_tests