### PR TITLE
Added option for setting status of a task in task.update

### DIFF
--- a/py/aon/aoncmd_taskupdate.py
+++ b/py/aon/aoncmd_taskupdate.py
@@ -116,6 +116,13 @@ def setupParser(parser):
         help='an optional comment to make on the task',
         default=None,
         type=str)
+    opt.add_argument(
+        '--status',
+        '-s',
+        metavar='STRING',
+        help='an optional status to assign to the task',
+        default=None,
+        type=str)
 
     output.add_argument(
         '--format-summary',
@@ -170,7 +177,8 @@ def process(args):
         owner,
         ccs,
         projects,
-        args.comment)
+        args.comment,
+        args.status)
 
     if args.format_id:
         print(result.id)

--- a/py/phl/phlcon_maniphest.py
+++ b/py/phl/phlcon_maniphest.py
@@ -147,7 +147,8 @@ def update_task(
         owner=None,
         ccs=None,
         projects=None,
-        comment=None):
+        comment=None,
+        status=None):
     """Update a Maniphest task using the supplied 'conduit'.
 
     :conduit: supports call()
@@ -179,6 +180,8 @@ def update_task(
         d['projectPHIDs'] = projects
     if comment is not None:
         d['comments'] = comment
+    if status is not None:
+        d['status'] = status
     response = conduit("maniphest.update", d)
     return CreateTaskResponse(**response)
 


### PR DESCRIPTION
Add an additional parameter for the update.task method that allows to set a Status for a task.
Useful if you want to close/resolve/invalidate a task directly from the commandline.