### PR TITLE
Fix write_text_file_atomic

### DIFF
--- a/py/phl/phlsys_fs.py
+++ b/py/phl/phlsys_fs.py
@@ -423,7 +423,7 @@ def write_text_file_atomic(path, text):
     dir_path = os.path.dirname(path)
     if dir_path:
         ensure_dir(dir_path)
-    tmpfd, tmppath = tempfile.mkstemp(text=True)
+    tmpfd, tmppath = tempfile.mkstemp(text=True, dir=dir_path)
     write_text_file(tmppath, text)
     os.close(tmpfd)
     os.rename(tmppath, path)

--- a/py/phl/phlsys_fs.py
+++ b/py/phl/phlsys_fs.py
@@ -424,9 +424,16 @@ def write_text_file_atomic(path, text):
     if dir_path:
         ensure_dir(dir_path)
     tmpfd, tmppath = tempfile.mkstemp(text=True, dir=dir_path)
-    write_text_file(tmppath, text)
-    os.close(tmpfd)
-    os.rename(tmppath, path)
+
+    try:
+        with os.fdopen(tmpfd, 'w') as f:
+            f.write(text)
+            f.flush()
+            os.fsync(tmpfd)
+        os.rename(tmppath, path)
+    except:
+        os.remove(tmppath)
+        raise
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This patch corrects two problems with ```phlsys_fs.write_text_file_atomic```:

1. The temporary file was created in default location which might be in different filesystem than target file. This would make final os.rename operation invalid.
2. The code did not address atomicity of the operation in case of system crash. A minimal consideration is making sure that relevant os-level file descriptors are fsynced before rename.

No automated tests are provided for (1) because manipulating mountpoints requires superuser privileges. Issue (2) is inherently nondeterministic, rare and quite difficult to reproduce.