### PR TITLE
Fix task-query results processing

### DIFF
--- a/py/aon/aoncmd_taskquery.py
+++ b/py/aon/aoncmd_taskquery.py
@@ -242,7 +242,7 @@ def process(args):
         order=order,
         text=args.text)
 
-    results = [dict(r.__dict__) for r in results]
+    results = [r._asdict() for r in results]
 
     for r in results:
         if r['statusName'] is None:

--- a/py/aon/aoncmd_taskquery.py
+++ b/py/aon/aoncmd_taskquery.py
@@ -266,7 +266,7 @@ def process(args):
 
 
 # -----------------------------------------------------------------------------
-# Copyright (C) 2013-2014 Bloomberg Finance L.P.
+# Copyright (C) 2013-2017 Bloomberg Finance L.P.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
__dict__ is no longer a property of collections.namedtuple. The
documented way of obtaining a dict (since 2.7 an OrderedDict) is with
the _asdict() method.

Test plan:

    $ arcyon tast-query --uri <local_phab_instance> --project arcyon

    Observe correct results and no stack trace

Signed-off-by: Charles Bailey <cbailey32@bloomberg.net>